### PR TITLE
[CES-549] Add polldev to touchscreen driver

### DIFF
--- a/Documentation/devicetree/bindings/input/touchscreen/edt-ft5x06.txt
+++ b/Documentation/devicetree/bindings/input/touchscreen/edt-ft5x06.txt
@@ -99,7 +99,7 @@ additionalProperties: false
 required:
   - compatible
   - reg
-  - interrupts
+  - interrupts or poll-interval
 
 examples:
   - |
@@ -113,6 +113,22 @@ examples:
         reg = <0x38>;
         interrupt-parent = <&gpio2>;
         interrupts = <5 IRQ_TYPE_EDGE_FALLING>;
+        reset-gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
+        wake-gpios = <&gpio4 9 GPIO_ACTIVE_HIGH>;
+      };
+    };
+
+examples:
+  - |
+    #include <dt-bindings/gpio/gpio.h>
+    #include <dt-bindings/interrupt-controller/arm-gic.h>
+    i2c {
+      #address-cells = <1>;
+      #size-cells = <0>;
+      edt-ft5x06@38 {
+        compatible = "edt,edt-ft5406";
+        reg = <0x38>;
+        poll-interval = <10>;
         reset-gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
         wake-gpios = <&gpio4 9 GPIO_ACTIVE_HIGH>;
       };

--- a/Documentation/devicetree/bindings/input/touchscreen/edt-ft5x06.txt
+++ b/Documentation/devicetree/bindings/input/touchscreen/edt-ft5x06.txt
@@ -1,65 +1,121 @@
-FocalTech EDT-FT5x06 Polytouch driver
-=====================================
+# SPDX-License-Identifier: GPL-2.0
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/input/touchscreen/edt-ft5x06.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
 
-There are 3 variants of the chip for various touch panel sizes
-FT5206GE1  2.8" .. 3.8"
-FT5306DE4  4.3" .. 7"
-FT5406EE8  7"   .. 8.9"
-FT5506EEG  7"   .. 8.9"
+title: FocalTech EDT-FT5x06 Polytouch Bindings
 
-The software interface is identical for all those chips, so that
-currently there is no need for the driver to distinguish between the
-different chips. Nevertheless distinct compatible strings are used so
-that a distinction can be added if necessary without changing the DT
-bindings.
+description: |
+             There are 5 variants of the chip for various touch panel sizes
+              FT5206GE1  2.8" .. 3.8"
+              FT5306DE4  4.3" .. 7"
+              FT5406EE8  7"   .. 8.9"
+              FT5506EEG  7"   .. 8.9"
+              FT5726NEI  5.7” .. 11.6"
 
+maintainers:
+  - Dmitry Torokhov <dmitry.torokhov@gmail.com>
 
-Required properties:
- - compatible:  "edt,edt-ft5206"
-           or:  "edt,edt-ft5306"
-           or:  "edt,edt-ft5406"
-           or:  "edt,edt-ft5506"
-           or:  "focaltech,ft6236"
+allOf:
+  - $ref: touchscreen.yaml#
+  - if:
+      properties:
+        compatible:
+          contains:
+            enum:
+              - evervision,ev-ft5726
 
- - reg:         I2C slave address of the chip (0x38)
- - interrupt-parent: a phandle pointing to the interrupt controller
-                     serving the interrupt for this chip
- - interrupts:       interrupt specification for the touchdetect
-                     interrupt
+    then:
+      properties:
+        offset-x: true
+        offset-y: true
 
-Optional properties:
- - reset-gpios: GPIO specification for the RESET input
- - wake-gpios:  GPIO specification for the WAKE input
+properties:
+  compatible:
+    enum:
+      - edt,edt-ft5206
+      - edt,edt-ft5306
+      - edt,edt-ft5406
+      - edt,edt-ft5506
+      - evervision,ev-ft5726
+      - focaltech,ft6236
 
- - pinctrl-names: should be "default"
- - pinctrl-0:   a phandle pointing to the pin settings for the
-                control gpios
+  reg:
+    maxItems: 1
 
- - threshold:   allows setting the "click"-threshold in the range
-                from 0 to 80.
+  interrupts:
+    maxItems: 1
 
- - gain:        allows setting the sensitivity in the range from 0 to
-                31. Note that lower values indicate higher
-                sensitivity.
+  reset-gpios:
+    maxItems: 1
 
- - offset:      allows setting the edge compensation in the range from
-                0 to 31.
- - touchscreen-size-x	   : See touchscreen.txt
- - touchscreen-size-y	   : See touchscreen.txt
- - touchscreen-fuzz-x      : See touchscreen.txt
- - touchscreen-fuzz-y      : See touchscreen.txt
- - touchscreen-inverted-x  : See touchscreen.txt
- - touchscreen-inverted-y  : See touchscreen.txt
- - touchscreen-swapped-x-y : See touchscreen.txt
+  wake-gpios:
+    maxItems: 1
 
-Example:
-	polytouch: edt-ft5x06@38 {
-		compatible = "edt,edt-ft5406", "edt,edt-ft5x06";
-		reg = <0x38>;
-		pinctrl-names = "default";
-		pinctrl-0 = <&edt_ft5x06_pins>;
-		interrupt-parent = <&gpio2>;
-		interrupts = <5 IRQ_TYPE_EDGE_FALLING>;
-		reset-gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
-		wake-gpios = <&gpio4 9 GPIO_ACTIVE_HIGH>;
-	};
+  wakeup-source: true
+
+  vcc-supply:
+    maxItems: 1
+
+  gain:
+    description: Allows setting the sensitivity in the range from 0 to 31.
+                 Note that lower values indicate higher sensitivity.
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 0
+    maximum: 31
+
+  offset:
+    description: Allows setting the edge compensation in the range from 0 to 31.
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 0
+    maximum: 31
+
+  offset-x:
+    description: Same as offset, but applies only to the horizontal position.
+                 Range from 0 to 80, only supported by evervision,ev-ft5726 devices.
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 0
+    maximum: 80
+
+  offset-y:
+    description: Same as offset, but applies only to the vertical position.
+                 Range from 0 to 80, only supported by evervision,ev-ft5726 devices.
+    $ref: /schemas/types.yaml#/definitions/uint32
+    minimum: 0
+    maximum: 80
+
+  touchscreen-size-x: true
+  touchscreen-size-y: true
+  touchscreen-fuzz-x: true
+  touchscreen-fuzz-y: true
+  touchscreen-inverted-x: true
+  touchscreen-inverted-y: true
+  touchscreen-swapped-x-y: true
+  interrupt-controller: true
+
+additionalProperties: false
+
+required:
+  - compatible
+  - reg
+  - interrupts
+
+examples:
+  - |
+    #include <dt-bindings/gpio/gpio.h>
+    #include <dt-bindings/interrupt-controller/arm-gic.h>
+    i2c {
+      #address-cells = <1>;
+      #size-cells = <0>;
+      edt-ft5x06@38 {
+        compatible = "edt,edt-ft5406";
+        reg = <0x38>;
+        interrupt-parent = <&gpio2>;
+        interrupts = <5 IRQ_TYPE_EDGE_FALLING>;
+        reset-gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
+        wake-gpios = <&gpio4 9 GPIO_ACTIVE_HIGH>;
+      };
+    };
+
+...

--- a/drivers/input/touchscreen/edt-ft5x06.c
+++ b/drivers/input/touchscreen/edt-ft5x06.c
@@ -1,20 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * Copyright (C) 2012 Simon Budig, <simon.budig@kernelconcepts.de>
  * Daniel Wagener <daniel.wagener@kernelconcepts.de> (M09 firmware support)
  * Lothar Waßmann <LW@KARO-electronics.de> (DT support)
- *
- * This software is licensed under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation, and
- * may be copied, distributed, and modified under those terms.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
 /*
@@ -25,20 +13,23 @@
  *    http://www.glyn.com/Products/Displays
  */
 
-#include <linux/module.h>
-#include <linux/ratelimit.h>
-#include <linux/irq.h>
+#include <linux/debugfs.h>
+#include <linux/delay.h>
+#include <linux/gpio/consumer.h>
+#include <linux/i2c.h>
 #include <linux/interrupt.h>
 #include <linux/input.h>
-#include <linux/i2c.h>
-#include <linux/uaccess.h>
-#include <linux/delay.h>
-#include <linux/debugfs.h>
-#include <linux/slab.h>
-#include <linux/gpio/consumer.h>
 #include <linux/input/mt.h>
 #include <linux/input/touchscreen.h>
-#include <linux/of_device.h>
+#include <linux/irq.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/ratelimit.h>
+#include <linux/regulator/consumer.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+
+#include <asm/unaligned.h>
 
 #define WORK_REGISTER_THRESHOLD		0x00
 #define WORK_REGISTER_REPORT_RATE	0x08
@@ -47,16 +38,25 @@
 #define WORK_REGISTER_NUM_X		0x33
 #define WORK_REGISTER_NUM_Y		0x34
 
+#define PMOD_REGISTER_ACTIVE		0x00
+#define PMOD_REGISTER_HIBERNATE		0x03
+
 #define M09_REGISTER_THRESHOLD		0x80
 #define M09_REGISTER_GAIN		0x92
 #define M09_REGISTER_OFFSET		0x93
 #define M09_REGISTER_NUM_X		0x94
 #define M09_REGISTER_NUM_Y		0x95
 
+#define EV_REGISTER_THRESHOLD		0x40
+#define EV_REGISTER_GAIN		0x41
+#define EV_REGISTER_OFFSET_Y		0x45
+#define EV_REGISTER_OFFSET_X		0x46
+
 #define NO_REGISTER			0xff
 
 #define WORK_REGISTER_OPMODE		0x3c
 #define FACTORY_REGISTER_OPMODE		0x01
+#define PMOD_REGISTER_OPMODE		0xa5
 
 #define TOUCH_EVENT_DOWN		0x00
 #define TOUCH_EVENT_UP			0x01
@@ -69,271 +69,296 @@
 #define EDT_RAW_DATA_RETRIES		100
 #define EDT_RAW_DATA_DELAY		1000 /* usec */
 
+enum edt_pmode {
+    EDT_PMODE_NOT_SUPPORTED,
+    EDT_PMODE_HIBERNATE,
+    EDT_PMODE_POWEROFF,
+};
+
 enum edt_ver {
-	M06,
-	M09,
+    EDT_M06,
+    EDT_M09,
+    EDT_M12,
+    EV_FT,
+    GENERIC_FT,
 };
 
 struct edt_reg_addr {
-	int reg_threshold;
-	int reg_report_rate;
-	int reg_gain;
-	int reg_offset;
-	int reg_num_x;
-	int reg_num_y;
+    int reg_threshold;
+    int reg_report_rate;
+    int reg_gain;
+    int reg_offset;
+    int reg_offset_x;
+    int reg_offset_y;
+    int reg_num_x;
+    int reg_num_y;
 };
 
 struct edt_ft5x06_ts_data {
-	struct i2c_client *client;
-	struct input_dev *input;
-	struct touchscreen_properties prop;
-	u16 num_x;
-	u16 num_y;
+    struct i2c_client *client;
+    struct input_dev *input;
+    struct touchscreen_properties prop;
+    u16 num_x;
+    u16 num_y;
+    struct regulator *vcc;
 
-	struct gpio_desc *reset_gpio;
-	struct gpio_desc *wake_gpio;
+    struct gpio_desc *reset_gpio;
+    struct gpio_desc *wake_gpio;
 
 #if defined(CONFIG_DEBUG_FS)
-	struct dentry *debug_dir;
+    struct dentry *debug_dir;
 	u8 *raw_buffer;
 	size_t raw_bufsize;
 #endif
 
-	struct mutex mutex;
-	bool factory_mode;
-	int threshold;
-	int gain;
-	int offset;
-	int report_rate;
-	int max_support_points;
+    struct mutex mutex;
+    bool factory_mode;
+    enum edt_pmode suspend_mode;
+    int threshold;
+    int gain;
+    int offset;
+    int offset_x;
+    int offset_y;
+    int report_rate;
+    int max_support_points;
 
-	char name[EDT_NAME_LEN];
+    char name[EDT_NAME_LEN];
 
-	struct edt_reg_addr reg_addr;
-	enum edt_ver version;
+    struct edt_reg_addr reg_addr;
+    enum edt_ver version;
 };
 
 struct edt_i2c_chip_data {
-	int  max_support_points;
+    int  max_support_points;
 };
 
 static int edt_ft5x06_ts_readwrite(struct i2c_client *client,
-				   u16 wr_len, u8 *wr_buf,
-				   u16 rd_len, u8 *rd_buf)
+                                   u16 wr_len, u8 *wr_buf,
+                                   u16 rd_len, u8 *rd_buf)
 {
-	struct i2c_msg wrmsg[2];
-	int i = 0;
-	int ret;
+    struct i2c_msg wrmsg[2];
+    int i = 0;
+    int ret;
 
-	if (wr_len) {
-		wrmsg[i].addr  = client->addr;
-		wrmsg[i].flags = 0;
-		wrmsg[i].len = wr_len;
-		wrmsg[i].buf = wr_buf;
-		i++;
-	}
-	if (rd_len) {
-		wrmsg[i].addr  = client->addr;
-		wrmsg[i].flags = I2C_M_RD;
-		wrmsg[i].len = rd_len;
-		wrmsg[i].buf = rd_buf;
-		i++;
-	}
+    if (wr_len) {
+        wrmsg[i].addr  = client->addr;
+        wrmsg[i].flags = 0;
+        wrmsg[i].len = wr_len;
+        wrmsg[i].buf = wr_buf;
+        i++;
+    }
+    if (rd_len) {
+        wrmsg[i].addr  = client->addr;
+        wrmsg[i].flags = I2C_M_RD;
+        wrmsg[i].len = rd_len;
+        wrmsg[i].buf = rd_buf;
+        i++;
+    }
 
-	ret = i2c_transfer(client->adapter, wrmsg, i);
-	if (ret < 0)
-		return ret;
-	if (ret != i)
-		return -EIO;
+    ret = i2c_transfer(client->adapter, wrmsg, i);
+    if (ret < 0)
+        return ret;
+    if (ret != i)
+        return -EIO;
 
-	return 0;
+    return 0;
 }
 
 static bool edt_ft5x06_ts_check_crc(struct edt_ft5x06_ts_data *tsdata,
-				    u8 *buf, int buflen)
+                                    u8 *buf, int buflen)
 {
-	int i;
-	u8 crc = 0;
+    int i;
+    u8 crc = 0;
 
-	for (i = 0; i < buflen - 1; i++)
-		crc ^= buf[i];
+    for (i = 0; i < buflen - 1; i++)
+        crc ^= buf[i];
 
-	if (crc != buf[buflen-1]) {
-		dev_err_ratelimited(&tsdata->client->dev,
-				    "crc error: 0x%02x expected, got 0x%02x\n",
-				    crc, buf[buflen-1]);
-		return false;
-	}
+    if (crc != buf[buflen-1]) {
+        dev_err_ratelimited(&tsdata->client->dev,
+                            "crc error: 0x%02x expected, got 0x%02x\n",
+                            crc, buf[buflen-1]);
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
 {
-	struct edt_ft5x06_ts_data *tsdata = dev_id;
-	struct device *dev = &tsdata->client->dev;
-	u8 cmd;
-	u8 rdbuf[63];
-	int i, type, x, y, id;
-	int offset, tplen, datalen, crclen;
-	int error;
+    struct edt_ft5x06_ts_data *tsdata = dev_id;
+    struct device *dev = &tsdata->client->dev;
+    u8 cmd;
+    u8 rdbuf[63];
+    int i, type, x, y, id;
+    int offset, tplen, datalen, crclen;
+    int error;
 
-	switch (tsdata->version) {
-	case M06:
-		cmd = 0xf9; /* tell the controller to send touch data */
-		offset = 5; /* where the actual touch data starts */
-		tplen = 4;  /* data comes in so called frames */
-		crclen = 1; /* length of the crc data */
-		break;
+    switch (tsdata->version) {
+    case EDT_M06:
+        cmd = 0xf9; /* tell the controller to send touch data */
+        offset = 5; /* where the actual touch data starts */
+        tplen = 4;  /* data comes in so called frames */
+        crclen = 1; /* length of the crc data */
+        break;
 
-	case M09:
-		cmd = 0x0;
-		offset = 3;
-		tplen = 6;
-		crclen = 0;
-		break;
+    case EDT_M09:
+    case EDT_M12:
+    case EV_FT:
+    case GENERIC_FT:
+        cmd = 0x0;
+        offset = 3;
+        tplen = 6;
+        crclen = 0;
+        break;
 
-	default:
-		goto out;
-	}
+    default:
+        goto out;
+    }
 
-	memset(rdbuf, 0, sizeof(rdbuf));
-	datalen = tplen * tsdata->max_support_points + offset + crclen;
+    memset(rdbuf, 0, sizeof(rdbuf));
+    datalen = tplen * tsdata->max_support_points + offset + crclen;
 
-	error = edt_ft5x06_ts_readwrite(tsdata->client,
-					sizeof(cmd), &cmd,
-					datalen, rdbuf);
-	if (error) {
-		dev_err_ratelimited(dev, "Unable to fetch data, error: %d\n",
-				    error);
-		goto out;
-	}
+    error = edt_ft5x06_ts_readwrite(tsdata->client,
+                                    sizeof(cmd), &cmd,
+                                    datalen, rdbuf);
+    if (error) {
+        dev_err_ratelimited(dev, "Unable to fetch data, error: %d\n",
+                            error);
+        goto out;
+    }
 
-	/* M09 does not send header or CRC */
-	if (tsdata->version == M06) {
-		if (rdbuf[0] != 0xaa || rdbuf[1] != 0xaa ||
-			rdbuf[2] != datalen) {
-			dev_err_ratelimited(dev,
-					"Unexpected header: %02x%02x%02x!\n",
-					rdbuf[0], rdbuf[1], rdbuf[2]);
-			goto out;
-		}
+    /* M09/M12 does not send header or CRC */
+    if (tsdata->version == EDT_M06) {
+        if (rdbuf[0] != 0xaa || rdbuf[1] != 0xaa ||
+            rdbuf[2] != datalen) {
+            dev_err_ratelimited(dev,
+                                "Unexpected header: %02x%02x%02x!\n",
+                                rdbuf[0], rdbuf[1], rdbuf[2]);
+            goto out;
+        }
 
-		if (!edt_ft5x06_ts_check_crc(tsdata, rdbuf, datalen))
-			goto out;
-	}
+        if (!edt_ft5x06_ts_check_crc(tsdata, rdbuf, datalen))
+            goto out;
+    }
 
-	for (i = 0; i < tsdata->max_support_points; i++) {
-		u8 *buf = &rdbuf[i * tplen + offset];
-		bool down;
+    for (i = 0; i < tsdata->max_support_points; i++) {
+        u8 *buf = &rdbuf[i * tplen + offset];
 
-		type = buf[0] >> 6;
-		/* ignore Reserved events */
-		if (type == TOUCH_EVENT_RESERVED)
-			continue;
+        type = buf[0] >> 6;
+        /* ignore Reserved events */
+        if (type == TOUCH_EVENT_RESERVED)
+            continue;
 
-		/* M06 sometimes sends bogus coordinates in TOUCH_DOWN */
-		if (tsdata->version == M06 && type == TOUCH_EVENT_DOWN)
-			continue;
+        /* M06 sometimes sends bogus coordinates in TOUCH_DOWN */
+        if (tsdata->version == EDT_M06 && type == TOUCH_EVENT_DOWN)
+            continue;
 
-		x = ((buf[0] << 8) | buf[1]) & 0x0fff;
-		y = ((buf[2] << 8) | buf[3]) & 0x0fff;
-		id = (buf[2] >> 4) & 0x0f;
-		down = type != TOUCH_EVENT_UP;
+        x = get_unaligned_be16(buf) & 0x0fff;
+        y = get_unaligned_be16(buf + 2) & 0x0fff;
+        /* The FT5x26 send the y coordinate first */
+        if (tsdata->version == EV_FT)
+            swap(x, y);
 
-		input_mt_slot(tsdata->input, id);
-		input_mt_report_slot_state(tsdata->input, MT_TOOL_FINGER, down);
+        id = (buf[2] >> 4) & 0x0f;
 
-		if (!down)
-			continue;
+        input_mt_slot(tsdata->input, id);
+        if (input_mt_report_slot_state(tsdata->input, MT_TOOL_FINGER,
+                                       type != TOUCH_EVENT_UP))
+            touchscreen_report_pos(tsdata->input, &tsdata->prop,
+                                   x, y, true);
+    }
 
-		touchscreen_report_pos(tsdata->input, &tsdata->prop, x, y,
-				       true);
-	}
+    input_mt_report_pointer_emulation(tsdata->input, true);
+    input_sync(tsdata->input);
 
-	input_mt_report_pointer_emulation(tsdata->input, true);
-	input_sync(tsdata->input);
-
-out:
-	return IRQ_HANDLED;
+    out:
+    return IRQ_HANDLED;
 }
 
 static int edt_ft5x06_register_write(struct edt_ft5x06_ts_data *tsdata,
-				     u8 addr, u8 value)
+                                     u8 addr, u8 value)
 {
-	u8 wrbuf[4];
+    u8 wrbuf[4];
 
-	switch (tsdata->version) {
-	case M06:
-		wrbuf[0] = tsdata->factory_mode ? 0xf3 : 0xfc;
-		wrbuf[1] = tsdata->factory_mode ? addr & 0x7f : addr & 0x3f;
-		wrbuf[2] = value;
-		wrbuf[3] = wrbuf[0] ^ wrbuf[1] ^ wrbuf[2];
-		return edt_ft5x06_ts_readwrite(tsdata->client, 4,
-					wrbuf, 0, NULL);
-	case M09:
-		wrbuf[0] = addr;
-		wrbuf[1] = value;
+    switch (tsdata->version) {
+    case EDT_M06:
+        wrbuf[0] = tsdata->factory_mode ? 0xf3 : 0xfc;
+        wrbuf[1] = tsdata->factory_mode ? addr & 0x7f : addr & 0x3f;
+        wrbuf[2] = value;
+        wrbuf[3] = wrbuf[0] ^ wrbuf[1] ^ wrbuf[2];
+        return edt_ft5x06_ts_readwrite(tsdata->client, 4,
+                                       wrbuf, 0, NULL);
 
-		return edt_ft5x06_ts_readwrite(tsdata->client, 2,
-					wrbuf, 0, NULL);
+    case EDT_M09:
+    case EDT_M12:
+    case EV_FT:
+    case GENERIC_FT:
+        wrbuf[0] = addr;
+        wrbuf[1] = value;
 
-	default:
-		return -EINVAL;
-	}
+        return edt_ft5x06_ts_readwrite(tsdata->client, 2,
+                                       wrbuf, 0, NULL);
+
+    default:
+        return -EINVAL;
+    }
 }
 
 static int edt_ft5x06_register_read(struct edt_ft5x06_ts_data *tsdata,
-				    u8 addr)
+                                    u8 addr)
 {
-	u8 wrbuf[2], rdbuf[2];
-	int error;
+    u8 wrbuf[2], rdbuf[2];
+    int error;
 
-	switch (tsdata->version) {
-	case M06:
-		wrbuf[0] = tsdata->factory_mode ? 0xf3 : 0xfc;
-		wrbuf[1] = tsdata->factory_mode ? addr & 0x7f : addr & 0x3f;
-		wrbuf[1] |= tsdata->factory_mode ? 0x80 : 0x40;
+    switch (tsdata->version) {
+    case EDT_M06:
+        wrbuf[0] = tsdata->factory_mode ? 0xf3 : 0xfc;
+        wrbuf[1] = tsdata->factory_mode ? addr & 0x7f : addr & 0x3f;
+        wrbuf[1] |= tsdata->factory_mode ? 0x80 : 0x40;
 
-		error = edt_ft5x06_ts_readwrite(tsdata->client, 2, wrbuf, 2,
-						rdbuf);
-		if (error)
-			return error;
+        error = edt_ft5x06_ts_readwrite(tsdata->client, 2, wrbuf, 2,
+                                        rdbuf);
+        if (error)
+            return error;
 
-		if ((wrbuf[0] ^ wrbuf[1] ^ rdbuf[0]) != rdbuf[1]) {
-			dev_err(&tsdata->client->dev,
-				"crc error: 0x%02x expected, got 0x%02x\n",
-				wrbuf[0] ^ wrbuf[1] ^ rdbuf[0],
-				rdbuf[1]);
-			return -EIO;
-		}
-		break;
+        if ((wrbuf[0] ^ wrbuf[1] ^ rdbuf[0]) != rdbuf[1]) {
+            dev_err(&tsdata->client->dev,
+                    "crc error: 0x%02x expected, got 0x%02x\n",
+                    wrbuf[0] ^ wrbuf[1] ^ rdbuf[0],
+                    rdbuf[1]);
+            return -EIO;
+        }
+        break;
 
-	case M09:
-		wrbuf[0] = addr;
-		error = edt_ft5x06_ts_readwrite(tsdata->client, 1,
-						wrbuf, 1, rdbuf);
-		if (error)
-			return error;
-		break;
+    case EDT_M09:
+    case EDT_M12:
+    case EV_FT:
+    case GENERIC_FT:
+        wrbuf[0] = addr;
+        error = edt_ft5x06_ts_readwrite(tsdata->client, 1,
+                                        wrbuf, 1, rdbuf);
+        if (error)
+            return error;
+        break;
 
-	default:
-		return -EINVAL;
-	}
+    default:
+        return -EINVAL;
+    }
 
-	return rdbuf[0];
+    return rdbuf[0];
 }
 
 struct edt_ft5x06_attribute {
-	struct device_attribute dattr;
-	size_t field_offset;
-	u8 limit_low;
-	u8 limit_high;
-	u8 addr_m06;
-	u8 addr_m09;
+    struct device_attribute dattr;
+    size_t field_offset;
+    u8 limit_low;
+    u8 limit_high;
+    u8 addr_m06;
+    u8 addr_m09;
+    u8 addr_ev;
 };
 
-#define EDT_ATTR(_field, _mode, _addr_m06, _addr_m09,			\
+#define EDT_ATTR(_field, _mode, _addr_m06, _addr_m09, _addr_ev,		\
 		_limit_low, _limit_high)				\
 	struct edt_ft5x06_attribute edt_ft5x06_attr_##_field = {	\
 		.dattr = __ATTR(_field, _mode,				\
@@ -342,150 +367,198 @@ struct edt_ft5x06_attribute {
 		.field_offset = offsetof(struct edt_ft5x06_ts_data, _field), \
 		.addr_m06 = _addr_m06,					\
 		.addr_m09 = _addr_m09,					\
+		.addr_ev  = _addr_ev,					\
 		.limit_low = _limit_low,				\
 		.limit_high = _limit_high,				\
 	}
 
 static ssize_t edt_ft5x06_setting_show(struct device *dev,
-				       struct device_attribute *dattr,
-				       char *buf)
+                                       struct device_attribute *dattr,
+                                       char *buf)
 {
-	struct i2c_client *client = to_i2c_client(dev);
-	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
-	struct edt_ft5x06_attribute *attr =
-			container_of(dattr, struct edt_ft5x06_attribute, dattr);
-	u8 *field = (u8 *)tsdata + attr->field_offset;
-	int val;
-	size_t count = 0;
-	int error = 0;
-	u8 addr;
+    struct i2c_client *client = to_i2c_client(dev);
+    struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
+    struct edt_ft5x06_attribute *attr =
+    container_of(dattr, struct edt_ft5x06_attribute, dattr);
+    u8 *field = (u8 *)tsdata + attr->field_offset;
+    int val;
+    size_t count = 0;
+    int error = 0;
+    u8 addr;
 
-	mutex_lock(&tsdata->mutex);
+    mutex_lock(&tsdata->mutex);
 
-	if (tsdata->factory_mode) {
-		error = -EIO;
-		goto out;
-	}
+    if (tsdata->factory_mode) {
+        error = -EIO;
+        goto out;
+    }
 
-	switch (tsdata->version) {
-	case M06:
-		addr = attr->addr_m06;
-		break;
+    switch (tsdata->version) {
+    case EDT_M06:
+        addr = attr->addr_m06;
+        break;
 
-	case M09:
-		addr = attr->addr_m09;
-		break;
+    case EDT_M09:
+    case EDT_M12:
+    case GENERIC_FT:
+        addr = attr->addr_m09;
+        break;
 
-	default:
-		error = -ENODEV;
-		goto out;
-	}
+    case EV_FT:
+        addr = attr->addr_ev;
+        break;
 
-	if (addr != NO_REGISTER) {
-		val = edt_ft5x06_register_read(tsdata, addr);
-		if (val < 0) {
-			error = val;
-			dev_err(&tsdata->client->dev,
-				"Failed to fetch attribute %s, error %d\n",
-				dattr->attr.name, error);
-			goto out;
-		}
-	} else {
-		val = *field;
-	}
+    default:
+        error = -ENODEV;
+        goto out;
+    }
 
-	if (val != *field) {
-		dev_warn(&tsdata->client->dev,
-			 "%s: read (%d) and stored value (%d) differ\n",
-			 dattr->attr.name, val, *field);
-		*field = val;
-	}
+    if (addr != NO_REGISTER) {
+        val = edt_ft5x06_register_read(tsdata, addr);
+        if (val < 0) {
+            error = val;
+            dev_err(&tsdata->client->dev,
+                    "Failed to fetch attribute %s, error %d\n",
+                    dattr->attr.name, error);
+            goto out;
+        }
+    } else {
+        val = *field;
+    }
 
-	count = scnprintf(buf, PAGE_SIZE, "%d\n", val);
-out:
-	mutex_unlock(&tsdata->mutex);
-	return error ?: count;
+    if (val != *field) {
+        dev_warn(&tsdata->client->dev,
+                 "%s: read (%d) and stored value (%d) differ\n",
+                 dattr->attr.name, val, *field);
+        *field = val;
+    }
+
+    count = scnprintf(buf, PAGE_SIZE, "%d\n", val);
+    out:
+    mutex_unlock(&tsdata->mutex);
+    return error ?: count;
 }
 
 static ssize_t edt_ft5x06_setting_store(struct device *dev,
-					struct device_attribute *dattr,
-					const char *buf, size_t count)
+                                        struct device_attribute *dattr,
+                                        const char *buf, size_t count)
 {
-	struct i2c_client *client = to_i2c_client(dev);
-	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
-	struct edt_ft5x06_attribute *attr =
-			container_of(dattr, struct edt_ft5x06_attribute, dattr);
-	u8 *field = (u8 *)tsdata + attr->field_offset;
-	unsigned int val;
-	int error;
-	u8 addr;
+    struct i2c_client *client = to_i2c_client(dev);
+    struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
+    struct edt_ft5x06_attribute *attr =
+    container_of(dattr, struct edt_ft5x06_attribute, dattr);
+    u8 *field = (u8 *)tsdata + attr->field_offset;
+    unsigned int val;
+    int error;
+    u8 addr;
 
-	mutex_lock(&tsdata->mutex);
+    mutex_lock(&tsdata->mutex);
 
-	if (tsdata->factory_mode) {
-		error = -EIO;
-		goto out;
-	}
+    if (tsdata->factory_mode) {
+        error = -EIO;
+        goto out;
+    }
 
-	error = kstrtouint(buf, 0, &val);
-	if (error)
-		goto out;
+    error = kstrtouint(buf, 0, &val);
+    if (error)
+        goto out;
 
-	if (val < attr->limit_low || val > attr->limit_high) {
-		error = -ERANGE;
-		goto out;
-	}
+    if (val < attr->limit_low || val > attr->limit_high) {
+        error = -ERANGE;
+        goto out;
+    }
 
-	switch (tsdata->version) {
-	case M06:
-		addr = attr->addr_m06;
-		break;
+    switch (tsdata->version) {
+    case EDT_M06:
+        addr = attr->addr_m06;
+        break;
 
-	case M09:
-		addr = attr->addr_m09;
-		break;
+    case EDT_M09:
+    case EDT_M12:
+    case GENERIC_FT:
+        addr = attr->addr_m09;
+        break;
 
-	default:
-		error = -ENODEV;
-		goto out;
-	}
+    case EV_FT:
+        addr = attr->addr_ev;
+        break;
 
-	if (addr != NO_REGISTER) {
-		error = edt_ft5x06_register_write(tsdata, addr, val);
-		if (error) {
-			dev_err(&tsdata->client->dev,
-				"Failed to update attribute %s, error: %d\n",
-				dattr->attr.name, error);
-			goto out;
-		}
-	}
-	*field = val;
+    default:
+        error = -ENODEV;
+        goto out;
+    }
 
-out:
-	mutex_unlock(&tsdata->mutex);
-	return error ?: count;
+    if (addr != NO_REGISTER) {
+        error = edt_ft5x06_register_write(tsdata, addr, val);
+        if (error) {
+            dev_err(&tsdata->client->dev,
+                    "Failed to update attribute %s, error: %d\n",
+                    dattr->attr.name, error);
+            goto out;
+        }
+    }
+    *field = val;
+
+    out:
+    mutex_unlock(&tsdata->mutex);
+    return error ?: count;
 }
 
+/* m06, m09: range 0-31, m12: range 0-5 */
 static EDT_ATTR(gain, S_IWUSR | S_IRUGO, WORK_REGISTER_GAIN,
-		M09_REGISTER_GAIN, 0, 31);
+                M09_REGISTER_GAIN, EV_REGISTER_GAIN, 0, 31);
+/* m06, m09: range 0-31, m12: range 0-16 */
 static EDT_ATTR(offset, S_IWUSR | S_IRUGO, WORK_REGISTER_OFFSET,
-		M09_REGISTER_OFFSET, 0, 31);
+                M09_REGISTER_OFFSET, NO_REGISTER, 0, 31);
+/* m06, m09, m12: no supported, ev_ft: range 0-80 */
+static EDT_ATTR(offset_x, S_IWUSR | S_IRUGO, NO_REGISTER, NO_REGISTER,
+                EV_REGISTER_OFFSET_X, 0, 80);
+/* m06, m09, m12: no supported, ev_ft: range 0-80 */
+static EDT_ATTR(offset_y, S_IWUSR | S_IRUGO, NO_REGISTER, NO_REGISTER,
+                EV_REGISTER_OFFSET_Y, 0, 80);
+/* m06: range 20 to 80, m09: range 0 to 30, m12: range 1 to 255... */
 static EDT_ATTR(threshold, S_IWUSR | S_IRUGO, WORK_REGISTER_THRESHOLD,
-		M09_REGISTER_THRESHOLD, 0, 80);
+                M09_REGISTER_THRESHOLD, EV_REGISTER_THRESHOLD, 0, 255);
+/* m06: range 3 to 14, m12: (0x64: 100Hz) */
 static EDT_ATTR(report_rate, S_IWUSR | S_IRUGO, WORK_REGISTER_REPORT_RATE,
-		NO_REGISTER, 3, 14);
+                NO_REGISTER, NO_REGISTER, 0, 255);
 
 static struct attribute *edt_ft5x06_attrs[] = {
-	&edt_ft5x06_attr_gain.dattr.attr,
-	&edt_ft5x06_attr_offset.dattr.attr,
-	&edt_ft5x06_attr_threshold.dattr.attr,
-	&edt_ft5x06_attr_report_rate.dattr.attr,
-	NULL
+        &edt_ft5x06_attr_gain.dattr.attr,
+        &edt_ft5x06_attr_offset.dattr.attr,
+        &edt_ft5x06_attr_offset_x.dattr.attr,
+        &edt_ft5x06_attr_offset_y.dattr.attr,
+        &edt_ft5x06_attr_threshold.dattr.attr,
+        &edt_ft5x06_attr_report_rate.dattr.attr,
+        NULL
 };
 
 static const struct attribute_group edt_ft5x06_attr_group = {
-	.attrs = edt_ft5x06_attrs,
+        .attrs = edt_ft5x06_attrs,
 };
+
+static void edt_ft5x06_restore_reg_parameters(struct edt_ft5x06_ts_data *tsdata)
+{
+    struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
+
+    edt_ft5x06_register_write(tsdata, reg_addr->reg_threshold,
+                              tsdata->threshold);
+    edt_ft5x06_register_write(tsdata, reg_addr->reg_gain,
+                              tsdata->gain);
+    if (reg_addr->reg_offset != NO_REGISTER)
+        edt_ft5x06_register_write(tsdata, reg_addr->reg_offset,
+                                  tsdata->offset);
+    if (reg_addr->reg_offset_x != NO_REGISTER)
+        edt_ft5x06_register_write(tsdata, reg_addr->reg_offset_x,
+                                  tsdata->offset_x);
+    if (reg_addr->reg_offset_y != NO_REGISTER)
+        edt_ft5x06_register_write(tsdata, reg_addr->reg_offset_y,
+                                  tsdata->offset_y);
+    if (reg_addr->reg_report_rate != NO_REGISTER)
+        edt_ft5x06_register_write(tsdata, reg_addr->reg_report_rate,
+                                  tsdata->report_rate);
+
+}
 
 #ifdef CONFIG_DEBUG_FS
 static int edt_ft5x06_factory_mode(struct edt_ft5x06_ts_data *tsdata)
@@ -494,6 +567,12 @@ static int edt_ft5x06_factory_mode(struct edt_ft5x06_ts_data *tsdata)
 	int retries = EDT_SWITCH_MODE_RETRIES;
 	int ret;
 	int error;
+
+	if (tsdata->version != EDT_M06) {
+		dev_err(&client->dev,
+			"No factory mode support for non-M06 devices\n");
+		return -EINVAL;
+	}
 
 	disable_irq(client->irq);
 
@@ -508,9 +587,6 @@ static int edt_ft5x06_factory_mode(struct edt_ft5x06_ts_data *tsdata)
 	}
 
 	/* mode register is 0x3c when in the work mode */
-	if (tsdata->version == M09)
-		goto m09_out;
-
 	error = edt_ft5x06_register_write(tsdata, WORK_REGISTER_OPMODE, 0x03);
 	if (error) {
 		dev_err(&client->dev,
@@ -543,18 +619,12 @@ err_out:
 	enable_irq(client->irq);
 
 	return error;
-
-m09_out:
-	dev_err(&client->dev, "No factory mode support for M09\n");
-	return -EINVAL;
-
 }
 
 static int edt_ft5x06_work_mode(struct edt_ft5x06_ts_data *tsdata)
 {
 	struct i2c_client *client = tsdata->client;
 	int retries = EDT_SWITCH_MODE_RETRIES;
-	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
 	int ret;
 	int error;
 
@@ -586,17 +656,7 @@ static int edt_ft5x06_work_mode(struct edt_ft5x06_ts_data *tsdata)
 	kfree(tsdata->raw_buffer);
 	tsdata->raw_buffer = NULL;
 
-	/* restore parameters */
-	edt_ft5x06_register_write(tsdata, reg_addr->reg_threshold,
-				  tsdata->threshold);
-	edt_ft5x06_register_write(tsdata, reg_addr->reg_gain,
-				  tsdata->gain);
-	edt_ft5x06_register_write(tsdata, reg_addr->reg_offset,
-				  tsdata->offset);
-	if (reg_addr->reg_report_rate != NO_REGISTER)
-		edt_ft5x06_register_write(tsdata, reg_addr->reg_report_rate,
-				  tsdata->report_rate);
-
+	edt_ft5x06_restore_reg_parameters(tsdata);
 	enable_irq(client->irq);
 
 	return 0;
@@ -717,13 +777,10 @@ static const struct file_operations debugfs_raw_data_fops = {
 	.read = edt_ft5x06_debugfs_raw_data_read,
 };
 
-static void
-edt_ft5x06_ts_prepare_debugfs(struct edt_ft5x06_ts_data *tsdata,
-			      const char *debugfs_name)
+static void edt_ft5x06_ts_prepare_debugfs(struct edt_ft5x06_ts_data *tsdata,
+					  const char *debugfs_name)
 {
 	tsdata->debug_dir = debugfs_create_dir(debugfs_name, NULL);
-	if (!tsdata->debug_dir)
-		return;
 
 	debugfs_create_u16("num_x", S_IRUSR, tsdata->debug_dir, &tsdata->num_x);
 	debugfs_create_u16("num_y", S_IRUSR, tsdata->debug_dir, &tsdata->num_y);
@@ -734,8 +791,7 @@ edt_ft5x06_ts_prepare_debugfs(struct edt_ft5x06_ts_data *tsdata,
 			    tsdata->debug_dir, tsdata, &debugfs_raw_data_fops);
 }
 
-static void
-edt_ft5x06_ts_teardown_debugfs(struct edt_ft5x06_ts_data *tsdata)
+static void edt_ft5x06_ts_teardown_debugfs(struct edt_ft5x06_ts_data *tsdata)
 {
 	debugfs_remove_recursive(tsdata->debug_dir);
 	kfree(tsdata->raw_buffer);
@@ -743,365 +799,613 @@ edt_ft5x06_ts_teardown_debugfs(struct edt_ft5x06_ts_data *tsdata)
 
 #else
 
-static inline void
-edt_ft5x06_ts_prepare_debugfs(struct edt_ft5x06_ts_data *tsdata,
-			      const char *debugfs_name)
+static int edt_ft5x06_factory_mode(struct edt_ft5x06_ts_data *tsdata)
+{
+    return -ENOSYS;
+}
+
+static void edt_ft5x06_ts_prepare_debugfs(struct edt_ft5x06_ts_data *tsdata,
+                                          const char *debugfs_name)
 {
 }
 
-static inline void
-edt_ft5x06_ts_teardown_debugfs(struct edt_ft5x06_ts_data *tsdata)
+static void edt_ft5x06_ts_teardown_debugfs(struct edt_ft5x06_ts_data *tsdata)
 {
 }
 
 #endif /* CONFIG_DEBUGFS */
 
 static int edt_ft5x06_ts_identify(struct i2c_client *client,
-					struct edt_ft5x06_ts_data *tsdata,
-					char *fw_version)
+                                  struct edt_ft5x06_ts_data *tsdata,
+                                  char *fw_version)
 {
-	u8 rdbuf[EDT_NAME_LEN];
-	char *p;
-	int error;
-	char *model_name = tsdata->name;
+    u8 rdbuf[EDT_NAME_LEN];
+    char *p;
+    int error;
+    char *model_name = tsdata->name;
 
-	/* see what we find if we assume it is a M06 *
-	 * if we get less than EDT_NAME_LEN, we don't want
-	 * to have garbage in there
-	 */
-	memset(rdbuf, 0, sizeof(rdbuf));
-	error = edt_ft5x06_ts_readwrite(client, 1, "\xbb",
-					EDT_NAME_LEN - 1, rdbuf);
-	if (error)
-		return error;
+    /* see what we find if we assume it is a M06 *
+     * if we get less than EDT_NAME_LEN, we don't want
+     * to have garbage in there
+     */
+    memset(rdbuf, 0, sizeof(rdbuf));
+    error = edt_ft5x06_ts_readwrite(client, 1, "\xBB",
+                                    EDT_NAME_LEN - 1, rdbuf);
+    if (error)
+        return error;
 
-	/* if we find something consistent, stay with that assumption
-	 * at least M09 won't send 3 bytes here
-	 */
-	if (!(strncasecmp(rdbuf + 1, "EP0", 3))) {
-		tsdata->version = M06;
+    /* Probe content for something consistent.
+     * M06 starts with a response byte, M12 gives the data directly.
+     * M09/Generic does not provide model number information.
+     */
+    if (!strncasecmp(rdbuf + 1, "EP0", 3)) {
+        tsdata->version = EDT_M06;
 
-		/* remove last '$' end marker */
-		rdbuf[EDT_NAME_LEN - 1] = '\0';
-		if (rdbuf[EDT_NAME_LEN - 2] == '$')
-			rdbuf[EDT_NAME_LEN - 2] = '\0';
+        /* remove last '$' end marker */
+        rdbuf[EDT_NAME_LEN - 1] = '\0';
+        if (rdbuf[EDT_NAME_LEN - 2] == '$')
+            rdbuf[EDT_NAME_LEN - 2] = '\0';
 
-		/* look for Model/Version separator */
-		p = strchr(rdbuf, '*');
-		if (p)
-			*p++ = '\0';
-		strlcpy(model_name, rdbuf + 1, EDT_NAME_LEN);
-		strlcpy(fw_version, p ? p : "", EDT_NAME_LEN);
-	} else {
-		/* since there are only two versions around (M06, M09) */
-		tsdata->version = M09;
+        /* look for Model/Version separator */
+        p = strchr(rdbuf, '*');
+        if (p)
+            *p++ = '\0';
+        strlcpy(model_name, rdbuf + 1, EDT_NAME_LEN);
+        strlcpy(fw_version, p ? p : "", EDT_NAME_LEN);
+    } else if (!strncasecmp(rdbuf, "EP0", 3)) {
+        tsdata->version = EDT_M12;
 
-		error = edt_ft5x06_ts_readwrite(client, 1, "\xA6",
-						2, rdbuf);
-		if (error)
-			return error;
+        /* remove last '$' end marker */
+        rdbuf[EDT_NAME_LEN - 2] = '\0';
+        if (rdbuf[EDT_NAME_LEN - 3] == '$')
+            rdbuf[EDT_NAME_LEN - 3] = '\0';
 
-		strlcpy(fw_version, rdbuf, 2);
+        /* look for Model/Version separator */
+        p = strchr(rdbuf, '*');
+        if (p)
+            *p++ = '\0';
+        strlcpy(model_name, rdbuf, EDT_NAME_LEN);
+        strlcpy(fw_version, p ? p : "", EDT_NAME_LEN);
+    } else {
+        /* If it is not an EDT M06/M12 touchscreen, then the model
+         * detection is a bit hairy. The different ft5x06
+         * firmares around don't reliably implement the
+         * identification registers. Well, we'll take a shot.
+         *
+         * The main difference between generic focaltec based
+         * touches and EDT M09 is that we know how to retrieve
+         * the max coordinates for the latter.
+         */
+        tsdata->version = GENERIC_FT;
 
-		error = edt_ft5x06_ts_readwrite(client, 1, "\xA8",
-						1, rdbuf);
-		if (error)
-			return error;
+        error = edt_ft5x06_ts_readwrite(client, 1, "\xA6",
+                                        2, rdbuf);
+        if (error)
+            return error;
 
-		snprintf(model_name, EDT_NAME_LEN, "EP0%i%i0M09",
-			rdbuf[0] >> 4, rdbuf[0] & 0x0F);
-	}
+        strlcpy(fw_version, rdbuf, 2);
 
-	return 0;
+        error = edt_ft5x06_ts_readwrite(client, 1, "\xA8",
+                                        1, rdbuf);
+        if (error)
+            return error;
+
+        /* This "model identification" is not exact. Unfortunately
+         * not all firmwares for the ft5x06 put useful values in
+         * the identification registers.
+         */
+        switch (rdbuf[0]) {
+        case 0x35:   /* EDT EP0350M09 */
+        case 0x43:   /* EDT EP0430M09 */
+        case 0x50:   /* EDT EP0500M09 */
+        case 0x57:   /* EDT EP0570M09 */
+        case 0x70:   /* EDT EP0700M09 */
+            tsdata->version = EDT_M09;
+            snprintf(model_name, EDT_NAME_LEN, "EP0%i%i0M09",
+                     rdbuf[0] >> 4, rdbuf[0] & 0x0F);
+            break;
+        case 0xa1:   /* EDT EP1010ML00 */
+            tsdata->version = EDT_M09;
+            snprintf(model_name, EDT_NAME_LEN, "EP%i%i0ML00",
+                     rdbuf[0] >> 4, rdbuf[0] & 0x0F);
+            break;
+        case 0x5a:   /* Solomon Goldentek Display */
+            snprintf(model_name, EDT_NAME_LEN, "GKTW50SCED1R0");
+            break;
+        case 0x59:  /* Evervision Display with FT5xx6 TS */
+            tsdata->version = EV_FT;
+            error = edt_ft5x06_ts_readwrite(client, 1, "\x53",
+                                            1, rdbuf);
+            if (error)
+                return error;
+            strlcpy(fw_version, rdbuf, 1);
+            snprintf(model_name, EDT_NAME_LEN,
+                     "EVERVISION-FT5726NEi");
+            break;
+        default:
+            snprintf(model_name, EDT_NAME_LEN,
+                     "generic ft5x06 (%02x)",
+                     rdbuf[0]);
+            break;
+        }
+    }
+
+    return 0;
 }
 
 static void edt_ft5x06_ts_get_defaults(struct device *dev,
-				       struct edt_ft5x06_ts_data *tsdata)
+                                       struct edt_ft5x06_ts_data *tsdata)
 {
-	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
-	u32 val;
-	int error;
+    struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
+    u32 val;
+    int error;
 
-	error = device_property_read_u32(dev, "threshold", &val);
-	if (!error) {
-		edt_ft5x06_register_write(tsdata, reg_addr->reg_threshold, val);
-		tsdata->threshold = val;
-	}
+    error = device_property_read_u32(dev, "threshold", &val);
+    if (!error) {
+        edt_ft5x06_register_write(tsdata, reg_addr->reg_threshold, val);
+        tsdata->threshold = val;
+    }
 
-	error = device_property_read_u32(dev, "gain", &val);
-	if (!error) {
-		edt_ft5x06_register_write(tsdata, reg_addr->reg_gain, val);
-		tsdata->gain = val;
-	}
+    error = device_property_read_u32(dev, "gain", &val);
+    if (!error) {
+        edt_ft5x06_register_write(tsdata, reg_addr->reg_gain, val);
+        tsdata->gain = val;
+    }
 
-	error = device_property_read_u32(dev, "offset", &val);
-	if (!error) {
-		edt_ft5x06_register_write(tsdata, reg_addr->reg_offset, val);
-		tsdata->offset = val;
-	}
+    error = device_property_read_u32(dev, "offset", &val);
+    if (!error) {
+        if (reg_addr->reg_offset != NO_REGISTER)
+            edt_ft5x06_register_write(tsdata,
+                                      reg_addr->reg_offset, val);
+        tsdata->offset = val;
+    }
+
+    error = device_property_read_u32(dev, "offset-x", &val);
+    if (!error) {
+        if (reg_addr->reg_offset_x != NO_REGISTER)
+            edt_ft5x06_register_write(tsdata,
+                                      reg_addr->reg_offset_x, val);
+        tsdata->offset_x = val;
+    }
+
+    error = device_property_read_u32(dev, "offset-y", &val);
+    if (!error) {
+        if (reg_addr->reg_offset_y != NO_REGISTER)
+            edt_ft5x06_register_write(tsdata,
+                                      reg_addr->reg_offset_y, val);
+        tsdata->offset_y = val;
+    }
 }
 
 static void
 edt_ft5x06_ts_get_parameters(struct edt_ft5x06_ts_data *tsdata)
 {
-	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
+    struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
 
-	tsdata->threshold = edt_ft5x06_register_read(tsdata,
-						     reg_addr->reg_threshold);
-	tsdata->gain = edt_ft5x06_register_read(tsdata, reg_addr->reg_gain);
-	tsdata->offset = edt_ft5x06_register_read(tsdata, reg_addr->reg_offset);
-	if (reg_addr->reg_report_rate != NO_REGISTER)
-		tsdata->report_rate = edt_ft5x06_register_read(tsdata,
-						reg_addr->reg_report_rate);
-	tsdata->num_x = edt_ft5x06_register_read(tsdata, reg_addr->reg_num_x);
-	tsdata->num_y = edt_ft5x06_register_read(tsdata, reg_addr->reg_num_y);
+    tsdata->threshold = edt_ft5x06_register_read(tsdata,
+                                                 reg_addr->reg_threshold);
+    tsdata->gain = edt_ft5x06_register_read(tsdata, reg_addr->reg_gain);
+    if (reg_addr->reg_offset != NO_REGISTER)
+        tsdata->offset =
+                edt_ft5x06_register_read(tsdata, reg_addr->reg_offset);
+    if (reg_addr->reg_offset_x != NO_REGISTER)
+        tsdata->offset_x = edt_ft5x06_register_read(tsdata,
+                                                    reg_addr->reg_offset_x);
+    if (reg_addr->reg_offset_y != NO_REGISTER)
+        tsdata->offset_y = edt_ft5x06_register_read(tsdata,
+                                                    reg_addr->reg_offset_y);
+    if (reg_addr->reg_report_rate != NO_REGISTER)
+        tsdata->report_rate = edt_ft5x06_register_read(tsdata,
+                                                       reg_addr->reg_report_rate);
+    if (tsdata->version == EDT_M06 ||
+        tsdata->version == EDT_M09 ||
+        tsdata->version == EDT_M12) {
+        tsdata->num_x = edt_ft5x06_register_read(tsdata,
+                                                 reg_addr->reg_num_x);
+        tsdata->num_y = edt_ft5x06_register_read(tsdata,
+                                                 reg_addr->reg_num_y);
+    } else {
+        tsdata->num_x = -1;
+        tsdata->num_y = -1;
+    }
 }
 
 static void
 edt_ft5x06_ts_set_regs(struct edt_ft5x06_ts_data *tsdata)
 {
-	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
+    struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
 
-	switch (tsdata->version) {
-	case M06:
-		reg_addr->reg_threshold = WORK_REGISTER_THRESHOLD;
-		reg_addr->reg_report_rate = WORK_REGISTER_REPORT_RATE;
-		reg_addr->reg_gain = WORK_REGISTER_GAIN;
-		reg_addr->reg_offset = WORK_REGISTER_OFFSET;
-		reg_addr->reg_num_x = WORK_REGISTER_NUM_X;
-		reg_addr->reg_num_y = WORK_REGISTER_NUM_Y;
-		break;
+    switch (tsdata->version) {
+    case EDT_M06:
+        reg_addr->reg_threshold = WORK_REGISTER_THRESHOLD;
+        reg_addr->reg_report_rate = WORK_REGISTER_REPORT_RATE;
+        reg_addr->reg_gain = WORK_REGISTER_GAIN;
+        reg_addr->reg_offset = WORK_REGISTER_OFFSET;
+        reg_addr->reg_offset_x = NO_REGISTER;
+        reg_addr->reg_offset_y = NO_REGISTER;
+        reg_addr->reg_num_x = WORK_REGISTER_NUM_X;
+        reg_addr->reg_num_y = WORK_REGISTER_NUM_Y;
+        break;
 
-	case M09:
-		reg_addr->reg_threshold = M09_REGISTER_THRESHOLD;
-		reg_addr->reg_report_rate = NO_REGISTER;
-		reg_addr->reg_gain = M09_REGISTER_GAIN;
-		reg_addr->reg_offset = M09_REGISTER_OFFSET;
-		reg_addr->reg_num_x = M09_REGISTER_NUM_X;
-		reg_addr->reg_num_y = M09_REGISTER_NUM_Y;
-		break;
-	}
+    case EDT_M09:
+    case EDT_M12:
+        reg_addr->reg_threshold = M09_REGISTER_THRESHOLD;
+        reg_addr->reg_report_rate = NO_REGISTER;
+        reg_addr->reg_gain = M09_REGISTER_GAIN;
+        reg_addr->reg_offset = M09_REGISTER_OFFSET;
+        reg_addr->reg_offset_x = NO_REGISTER;
+        reg_addr->reg_offset_y = NO_REGISTER;
+        reg_addr->reg_num_x = M09_REGISTER_NUM_X;
+        reg_addr->reg_num_y = M09_REGISTER_NUM_Y;
+        break;
+
+    case EV_FT:
+        reg_addr->reg_threshold = EV_REGISTER_THRESHOLD;
+        reg_addr->reg_gain = EV_REGISTER_GAIN;
+        reg_addr->reg_offset = NO_REGISTER;
+        reg_addr->reg_offset_x = EV_REGISTER_OFFSET_X;
+        reg_addr->reg_offset_y = EV_REGISTER_OFFSET_Y;
+        reg_addr->reg_num_x = NO_REGISTER;
+        reg_addr->reg_num_y = NO_REGISTER;
+        reg_addr->reg_report_rate = NO_REGISTER;
+        break;
+
+    case GENERIC_FT:
+        /* this is a guesswork */
+        reg_addr->reg_threshold = M09_REGISTER_THRESHOLD;
+        reg_addr->reg_gain = M09_REGISTER_GAIN;
+        reg_addr->reg_offset = M09_REGISTER_OFFSET;
+        reg_addr->reg_offset_x = NO_REGISTER;
+        reg_addr->reg_offset_y = NO_REGISTER;
+        break;
+    }
+}
+
+static void edt_ft5x06_disable_regulator(void *arg)
+{
+    struct edt_ft5x06_ts_data *data = arg;
+
+    regulator_disable(data->vcc);
 }
 
 static int edt_ft5x06_ts_probe(struct i2c_client *client,
-					 const struct i2c_device_id *id)
+                               const struct i2c_device_id *id)
 {
-	const struct edt_i2c_chip_data *chip_data;
-	struct edt_ft5x06_ts_data *tsdata;
-	struct input_dev *input;
-	unsigned long irq_flags;
-	int error;
-	char fw_version[EDT_NAME_LEN];
+    const struct edt_i2c_chip_data *chip_data;
+    struct edt_ft5x06_ts_data *tsdata;
+    u8 buf[2] = { 0xfc, 0x00 };
+    struct input_dev *input;
+    unsigned long irq_flags;
+    int error;
+    char fw_version[EDT_NAME_LEN];
 
-	dev_dbg(&client->dev, "probing for EDT FT5x06 I2C\n");
+    dev_dbg(&client->dev, "probing for EDT FT5x06 I2C\n");
 
-	tsdata = devm_kzalloc(&client->dev, sizeof(*tsdata), GFP_KERNEL);
-	if (!tsdata) {
-		dev_err(&client->dev, "failed to allocate driver data.\n");
-		return -ENOMEM;
-	}
+    tsdata = devm_kzalloc(&client->dev, sizeof(*tsdata), GFP_KERNEL);
+    if (!tsdata) {
+        dev_err(&client->dev, "failed to allocate driver data.\n");
+        return -ENOMEM;
+    }
 
-	chip_data = of_device_get_match_data(&client->dev);
-	if (!chip_data)
-		chip_data = (const struct edt_i2c_chip_data *)id->driver_data;
-	if (!chip_data || !chip_data->max_support_points) {
-		dev_err(&client->dev, "invalid or missing chip data\n");
-		return -EINVAL;
-	}
+    chip_data = device_get_match_data(&client->dev);
+    if (!chip_data)
+        chip_data = (const struct edt_i2c_chip_data *)id->driver_data;
+    if (!chip_data || !chip_data->max_support_points) {
+        dev_err(&client->dev, "invalid or missing chip data\n");
+        return -EINVAL;
+    }
 
-	tsdata->max_support_points = chip_data->max_support_points;
+    tsdata->max_support_points = chip_data->max_support_points;
 
-	tsdata->reset_gpio = devm_gpiod_get_optional(&client->dev,
-						     "reset", GPIOD_OUT_HIGH);
-	if (IS_ERR(tsdata->reset_gpio)) {
-		error = PTR_ERR(tsdata->reset_gpio);
-		dev_err(&client->dev,
-			"Failed to request GPIO reset pin, error %d\n", error);
-		return error;
-	}
+    tsdata->vcc = devm_regulator_get(&client->dev, "vcc");
+    if (IS_ERR(tsdata->vcc)) {
+        error = PTR_ERR(tsdata->vcc);
+        if (error != -EPROBE_DEFER)
+            dev_err(&client->dev,
+                    "failed to request regulator: %d\n", error);
+        return error;
+    }
 
-	tsdata->wake_gpio = devm_gpiod_get_optional(&client->dev,
-						    "wake", GPIOD_OUT_LOW);
-	if (IS_ERR(tsdata->wake_gpio)) {
-		error = PTR_ERR(tsdata->wake_gpio);
-		dev_err(&client->dev,
-			"Failed to request GPIO wake pin, error %d\n", error);
-		return error;
-	}
+    error = regulator_enable(tsdata->vcc);
+    if (error < 0) {
+        dev_err(&client->dev, "failed to enable vcc: %d\n", error);
+        return error;
+    }
 
-	if (tsdata->wake_gpio) {
-		usleep_range(5000, 6000);
-		gpiod_set_value_cansleep(tsdata->wake_gpio, 1);
-	}
+    error = devm_add_action_or_reset(&client->dev,
+                                     edt_ft5x06_disable_regulator,
+                                     tsdata);
+    if (error)
+        return error;
 
-	if (tsdata->reset_gpio) {
-		usleep_range(5000, 6000);
-		gpiod_set_value_cansleep(tsdata->reset_gpio, 0);
-		msleep(300);
-	}
+    tsdata->reset_gpio = devm_gpiod_get_optional(&client->dev,
+                                                 "reset", GPIOD_OUT_HIGH);
+    if (IS_ERR(tsdata->reset_gpio)) {
+        error = PTR_ERR(tsdata->reset_gpio);
+        dev_err(&client->dev,
+                "Failed to request GPIO reset pin, error %d\n", error);
+        return error;
+    }
 
-	input = devm_input_allocate_device(&client->dev);
-	if (!input) {
-		dev_err(&client->dev, "failed to allocate input device.\n");
-		return -ENOMEM;
-	}
+    tsdata->wake_gpio = devm_gpiod_get_optional(&client->dev,
+                                                "wake", GPIOD_OUT_LOW);
+    if (IS_ERR(tsdata->wake_gpio)) {
+        error = PTR_ERR(tsdata->wake_gpio);
+        dev_err(&client->dev,
+                "Failed to request GPIO wake pin, error %d\n", error);
+        return error;
+    }
 
-	mutex_init(&tsdata->mutex);
-	tsdata->client = client;
-	tsdata->input = input;
-	tsdata->factory_mode = false;
+    /*
+     * Check which sleep modes we can support. Power-off requieres the
+     * reset-pin to ensure correct power-down/power-up behaviour. Start with
+     * the EDT_PMODE_POWEROFF test since this is the deepest possible sleep
+     * mode.
+     */
+    if (tsdata->reset_gpio)
+        tsdata->suspend_mode = EDT_PMODE_POWEROFF;
+    else if (tsdata->wake_gpio)
+        tsdata->suspend_mode = EDT_PMODE_HIBERNATE;
+    else
+        tsdata->suspend_mode = EDT_PMODE_NOT_SUPPORTED;
 
-	error = edt_ft5x06_ts_identify(client, tsdata, fw_version);
-	if (error) {
-		dev_err(&client->dev, "touchscreen probe failed\n");
-		return error;
-	}
+    if (tsdata->wake_gpio) {
+        usleep_range(5000, 6000);
+        gpiod_set_value_cansleep(tsdata->wake_gpio, 1);
+    }
 
-	edt_ft5x06_ts_set_regs(tsdata);
-	edt_ft5x06_ts_get_defaults(&client->dev, tsdata);
-	edt_ft5x06_ts_get_parameters(tsdata);
+    if (tsdata->reset_gpio) {
+        usleep_range(5000, 6000);
+        gpiod_set_value_cansleep(tsdata->reset_gpio, 0);
+        msleep(300);
+    }
 
-	dev_dbg(&client->dev,
-		"Model \"%s\", Rev. \"%s\", %dx%d sensors\n",
-		tsdata->name, fw_version, tsdata->num_x, tsdata->num_y);
+    input = devm_input_allocate_device(&client->dev);
+    if (!input) {
+        dev_err(&client->dev, "failed to allocate input device.\n");
+        return -ENOMEM;
+    }
 
-	input->name = tsdata->name;
-	input->id.bustype = BUS_I2C;
-	input->dev.parent = &client->dev;
+    mutex_init(&tsdata->mutex);
+    tsdata->client = client;
+    tsdata->input = input;
+    tsdata->factory_mode = false;
 
-	input_set_abs_params(input, ABS_MT_POSITION_X,
-			     0, tsdata->num_x * 64 - 1, 0, 0);
-	input_set_abs_params(input, ABS_MT_POSITION_Y,
-			     0, tsdata->num_y * 64 - 1, 0, 0);
+    error = edt_ft5x06_ts_identify(client, tsdata, fw_version);
+    if (error) {
+        dev_err(&client->dev, "touchscreen probe failed\n");
+        return error;
+    }
 
-	touchscreen_parse_properties(input, true, &tsdata->prop);
+    /*
+     * Dummy read access. EP0700MLP1 returns bogus data on the first
+     * register read access and ignores writes.
+     */
+    edt_ft5x06_ts_readwrite(tsdata->client, 2, buf, 2, buf);
 
-	error = input_mt_init_slots(input, tsdata->max_support_points,
-				INPUT_MT_DIRECT);
-	if (error) {
-		dev_err(&client->dev, "Unable to init MT slots.\n");
-		return error;
-	}
+    edt_ft5x06_ts_set_regs(tsdata);
+    edt_ft5x06_ts_get_defaults(&client->dev, tsdata);
+    edt_ft5x06_ts_get_parameters(tsdata);
 
-	i2c_set_clientdata(client, tsdata);
+    dev_dbg(&client->dev,
+            "Model \"%s\", Rev. \"%s\", %dx%d sensors\n",
+            tsdata->name, fw_version, tsdata->num_x, tsdata->num_y);
 
-	irq_flags = irq_get_trigger_type(client->irq);
-	if (irq_flags == IRQF_TRIGGER_NONE)
-		irq_flags = IRQF_TRIGGER_FALLING;
-	irq_flags |= IRQF_ONESHOT;
+    input->name = tsdata->name;
+    input->id.bustype = BUS_I2C;
+    input->dev.parent = &client->dev;
 
-	error = devm_request_threaded_irq(&client->dev, client->irq,
-					NULL, edt_ft5x06_ts_isr, irq_flags,
-					client->name, tsdata);
-	if (error) {
-		dev_err(&client->dev, "Unable to request touchscreen IRQ.\n");
-		return error;
-	}
+    if (tsdata->version == EDT_M06 ||
+        tsdata->version == EDT_M09 ||
+        tsdata->version == EDT_M12) {
+        input_set_abs_params(input, ABS_MT_POSITION_X,
+                             0, tsdata->num_x * 64 - 1, 0, 0);
+        input_set_abs_params(input, ABS_MT_POSITION_Y,
+                             0, tsdata->num_y * 64 - 1, 0, 0);
+    } else {
+        /* Unknown maximum values. Specify via devicetree */
+        input_set_abs_params(input, ABS_MT_POSITION_X,
+                             0, 65535, 0, 0);
+        input_set_abs_params(input, ABS_MT_POSITION_Y,
+                             0, 65535, 0, 0);
+    }
 
-	error = sysfs_create_group(&client->dev.kobj, &edt_ft5x06_attr_group);
-	if (error)
-		return error;
+    touchscreen_parse_properties(input, true, &tsdata->prop);
 
-	error = input_register_device(input);
-	if (error)
-		goto err_remove_attrs;
+    error = input_mt_init_slots(input, tsdata->max_support_points,
+                                INPUT_MT_DIRECT);
+    if (error) {
+        dev_err(&client->dev, "Unable to init MT slots.\n");
+        return error;
+    }
 
-	edt_ft5x06_ts_prepare_debugfs(tsdata, dev_driver_string(&client->dev));
-	device_init_wakeup(&client->dev, 1);
+    i2c_set_clientdata(client, tsdata);
 
-	dev_dbg(&client->dev,
-		"EDT FT5x06 initialized: IRQ %d, WAKE pin %d, Reset pin %d.\n",
-		client->irq,
-		tsdata->wake_gpio ? desc_to_gpio(tsdata->wake_gpio) : -1,
-		tsdata->reset_gpio ? desc_to_gpio(tsdata->reset_gpio) : -1);
+    irq_flags = irq_get_trigger_type(client->irq);
+    if (irq_flags == IRQF_TRIGGER_NONE)
+        irq_flags = IRQF_TRIGGER_FALLING;
+    irq_flags |= IRQF_ONESHOT;
 
-	return 0;
+    error = devm_request_threaded_irq(&client->dev, client->irq,
+                                      NULL, edt_ft5x06_ts_isr, irq_flags,
+                                      client->name, tsdata);
+    if (error) {
+        dev_err(&client->dev, "Unable to request touchscreen IRQ.\n");
+        return error;
+    }
 
-err_remove_attrs:
-	sysfs_remove_group(&client->dev.kobj, &edt_ft5x06_attr_group);
-	return error;
+    error = devm_device_add_group(&client->dev, &edt_ft5x06_attr_group);
+    if (error)
+        return error;
+
+    error = input_register_device(input);
+    if (error)
+        return error;
+
+    edt_ft5x06_ts_prepare_debugfs(tsdata, dev_driver_string(&client->dev));
+
+    dev_dbg(&client->dev,
+            "EDT FT5x06 initialized: IRQ %d, WAKE pin %d, Reset pin %d.\n",
+            client->irq,
+            tsdata->wake_gpio ? desc_to_gpio(tsdata->wake_gpio) : -1,
+            tsdata->reset_gpio ? desc_to_gpio(tsdata->reset_gpio) : -1);
+
+    return 0;
 }
 
 static int edt_ft5x06_ts_remove(struct i2c_client *client)
 {
-	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
+    struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
 
-	edt_ft5x06_ts_teardown_debugfs(tsdata);
-	sysfs_remove_group(&client->dev.kobj, &edt_ft5x06_attr_group);
+    edt_ft5x06_ts_teardown_debugfs(tsdata);
 
-	return 0;
+    return 0;
 }
 
 static int __maybe_unused edt_ft5x06_ts_suspend(struct device *dev)
 {
-	struct i2c_client *client = to_i2c_client(dev);
+    struct i2c_client *client = to_i2c_client(dev);
+    struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
+    struct gpio_desc *reset_gpio = tsdata->reset_gpio;
+    int ret;
 
-	if (device_may_wakeup(dev))
-		enable_irq_wake(client->irq);
+    if (device_may_wakeup(dev))
+        return 0;
 
-	return 0;
+    if (tsdata->suspend_mode == EDT_PMODE_NOT_SUPPORTED)
+        return 0;
+
+    /* Enter hibernate mode. */
+    ret = edt_ft5x06_register_write(tsdata, PMOD_REGISTER_OPMODE,
+                                    PMOD_REGISTER_HIBERNATE);
+    if (ret)
+        dev_warn(dev, "Failed to set hibernate mode\n");
+
+    if (tsdata->suspend_mode == EDT_PMODE_HIBERNATE)
+        return 0;
+
+    /*
+     * Power-off according the datasheet. Cut the power may leaf the irq
+     * line in an undefined state depending on the host pull resistor
+     * settings. Disable the irq to avoid adjusting each host till the
+     * device is back in a full functional state.
+     */
+    disable_irq(tsdata->client->irq);
+
+    gpiod_set_value_cansleep(reset_gpio, 1);
+    usleep_range(1000, 2000);
+
+    ret = regulator_disable(tsdata->vcc);
+    if (ret)
+        dev_warn(dev, "Failed to disable vcc\n");
+
+    return 0;
 }
 
 static int __maybe_unused edt_ft5x06_ts_resume(struct device *dev)
 {
-	struct i2c_client *client = to_i2c_client(dev);
+    struct i2c_client *client = to_i2c_client(dev);
+    struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
+    int ret = 0;
 
-	if (device_may_wakeup(dev))
-		disable_irq_wake(client->irq);
+    if (device_may_wakeup(dev))
+        return 0;
 
-	return 0;
+    if (tsdata->suspend_mode == EDT_PMODE_NOT_SUPPORTED)
+        return 0;
+
+    if (tsdata->suspend_mode == EDT_PMODE_POWEROFF) {
+        struct gpio_desc *reset_gpio = tsdata->reset_gpio;
+
+        /*
+         * We can't check if the regulator is a dummy or a real
+         * regulator. So we need to specify the 5ms reset time (T_rst)
+         * here instead of the 100us T_rtp time. We also need to wait
+         * 300ms in case it was a real supply and the power was cutted
+         * of. Toggle the reset pin is also a way to exit the hibernate
+         * mode.
+         */
+        gpiod_set_value_cansleep(reset_gpio, 1);
+        usleep_range(5000, 6000);
+
+        ret = regulator_enable(tsdata->vcc);
+        if (ret) {
+            dev_err(dev, "Failed to enable vcc\n");
+            return ret;
+        }
+
+        usleep_range(1000, 2000);
+        gpiod_set_value_cansleep(reset_gpio, 0);
+        msleep(300);
+
+        edt_ft5x06_restore_reg_parameters(tsdata);
+        enable_irq(tsdata->client->irq);
+
+        if (tsdata->factory_mode)
+            ret = edt_ft5x06_factory_mode(tsdata);
+    } else {
+        struct gpio_desc *wake_gpio = tsdata->wake_gpio;
+
+        gpiod_set_value_cansleep(wake_gpio, 0);
+        usleep_range(5000, 6000);
+        gpiod_set_value_cansleep(wake_gpio, 1);
+    }
+
+
+    return ret;
 }
 
 static SIMPLE_DEV_PM_OPS(edt_ft5x06_ts_pm_ops,
-			 edt_ft5x06_ts_suspend, edt_ft5x06_ts_resume);
+        edt_ft5x06_ts_suspend, edt_ft5x06_ts_resume);
 
 static const struct edt_i2c_chip_data edt_ft5x06_data = {
-	.max_support_points = 5,
+        .max_support_points = 5,
 };
 
 static const struct edt_i2c_chip_data edt_ft5506_data = {
-	.max_support_points = 10,
+        .max_support_points = 10,
 };
 
 static const struct edt_i2c_chip_data edt_ft6236_data = {
-	.max_support_points = 2,
+        .max_support_points = 2,
 };
 
 static const struct i2c_device_id edt_ft5x06_ts_id[] = {
-	{ .name = "edt-ft5x06", .driver_data = (long)&edt_ft5x06_data },
-	{ .name = "edt-ft5506", .driver_data = (long)&edt_ft5506_data },
-	/* Note no edt- prefix for compatibility with the ft6236.c driver */
-	{ .name = "ft6236", .driver_data = (long)&edt_ft6236_data },
-	{ /* sentinel */ }
+        { .name = "edt-ft5x06", .driver_data = (long)&edt_ft5x06_data },
+        { .name = "edt-ft5506", .driver_data = (long)&edt_ft5506_data },
+        { .name = "ev-ft5726", .driver_data = (long)&edt_ft5506_data },
+        /* Note no edt- prefix for compatibility with the ft6236.c driver */
+        { .name = "ft6236", .driver_data = (long)&edt_ft6236_data },
+        { /* sentinel */ }
 };
 MODULE_DEVICE_TABLE(i2c, edt_ft5x06_ts_id);
 
-#ifdef CONFIG_OF
 static const struct of_device_id edt_ft5x06_of_match[] = {
-	{ .compatible = "edt,edt-ft5206", .data = &edt_ft5x06_data },
-	{ .compatible = "edt,edt-ft5306", .data = &edt_ft5x06_data },
-	{ .compatible = "edt,edt-ft5406", .data = &edt_ft5x06_data },
-	{ .compatible = "edt,edt-ft5506", .data = &edt_ft5506_data },
-	/* Note focaltech vendor prefix for compatibility with ft6236.c */
-	{ .compatible = "focaltech,ft6236", .data = &edt_ft6236_data },
-	{ /* sentinel */ }
+        { .compatible = "edt,edt-ft5206", .data = &edt_ft5x06_data },
+        { .compatible = "edt,edt-ft5306", .data = &edt_ft5x06_data },
+        { .compatible = "edt,edt-ft5406", .data = &edt_ft5x06_data },
+        { .compatible = "edt,edt-ft5506", .data = &edt_ft5506_data },
+        { .compatible = "evervision,ev-ft5726", .data = &edt_ft5506_data },
+        /* Note focaltech vendor prefix for compatibility with ft6236.c */
+        { .compatible = "focaltech,ft6236", .data = &edt_ft6236_data },
+        { /* sentinel */ }
 };
 MODULE_DEVICE_TABLE(of, edt_ft5x06_of_match);
-#endif
 
 static struct i2c_driver edt_ft5x06_ts_driver = {
-	.driver = {
-		.name = "edt_ft5x06",
-		.of_match_table = of_match_ptr(edt_ft5x06_of_match),
-		.pm = &edt_ft5x06_ts_pm_ops,
-	},
-	.id_table = edt_ft5x06_ts_id,
-	.probe    = edt_ft5x06_ts_probe,
-	.remove   = edt_ft5x06_ts_remove,
+        .driver = {
+                .name = "edt_ft5x06",
+                .of_match_table = edt_ft5x06_of_match,
+                .pm = &edt_ft5x06_ts_pm_ops,
+                .probe_type = PROBE_PREFER_ASYNCHRONOUS,
+        },
+        .id_table = edt_ft5x06_ts_id,
+        .probe    = edt_ft5x06_ts_probe,
+        .remove   = edt_ft5x06_ts_remove,
 };
 
 module_i2c_driver(edt_ft5x06_ts_driver);
 
 MODULE_AUTHOR("Simon Budig <simon.budig@kernelconcepts.de>");
 MODULE_DESCRIPTION("EDT FT5x06 I2C Touchscreen Driver");
-MODULE_LICENSE("GPL");
+MODULE_LICENSE("GPL v2");

--- a/drivers/input/touchscreen/edt-ft5x06.c
+++ b/drivers/input/touchscreen/edt-ft5x06.c
@@ -20,10 +20,12 @@
 #include <linux/interrupt.h>
 #include <linux/input.h>
 #include <linux/input/mt.h>
+#include <linux/input-polldev.h>
 #include <linux/input/touchscreen.h>
 #include <linux/irq.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/of_device.h>
 #include <linux/ratelimit.h>
 #include <linux/regulator/consumer.h>
 #include <linux/slab.h>
@@ -46,6 +48,13 @@
 #define M09_REGISTER_OFFSET		0x93
 #define M09_REGISTER_NUM_X		0x94
 #define M09_REGISTER_NUM_Y		0x95
+
+#define M09_ID_G_MODE		0xa4
+#define M09_ID_G_MODE_POLL	0x00
+#define M09_ID_G_MODE_IRQ	0x01
+
+#define M09_ID_G_PMODE				0xa5
+#define M09_ID_G_PMODE_ACTIVE		0x00
 
 #define EV_REGISTER_THRESHOLD		0x40
 #define EV_REGISTER_GAIN		0x41
@@ -83,6 +92,11 @@ enum edt_ver {
     GENERIC_FT,
 };
 
+enum readout_mode {
+    EDT_READOUT_MODE_POLL,
+    EDT_READOUT_MODE_IRQ,
+};
+
 struct edt_reg_addr {
     int reg_threshold;
     int reg_report_rate;
@@ -97,6 +111,9 @@ struct edt_reg_addr {
 struct edt_ft5x06_ts_data {
     struct i2c_client *client;
     struct input_dev *input;
+#if IS_ENABLED(CONFIG_INPUT_POLLDEV)
+    struct input_polled_dev *polldev;
+#endif
     struct touchscreen_properties prop;
     u16 num_x;
     u16 num_y;
@@ -183,9 +200,8 @@ static bool edt_ft5x06_ts_check_crc(struct edt_ft5x06_ts_data *tsdata,
     return true;
 }
 
-static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
+static void edt_ft5x06_report(struct edt_ft5x06_ts_data *tsdata)
 {
-    struct edt_ft5x06_ts_data *tsdata = dev_id;
     struct device *dev = &tsdata->client->dev;
     u8 cmd;
     u8 rdbuf[63];
@@ -212,19 +228,16 @@ static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
         break;
 
     default:
-        goto out;
+        return;
     }
 
     memset(rdbuf, 0, sizeof(rdbuf));
     datalen = tplen * tsdata->max_support_points + offset + crclen;
-
-    error = edt_ft5x06_ts_readwrite(tsdata->client,
-                                    sizeof(cmd), &cmd,
-                                    datalen, rdbuf);
+    error = edt_ft5x06_ts_readwrite(tsdata->client, sizeof(cmd), &cmd, datalen, rdbuf);
     if (error) {
         dev_err_ratelimited(dev, "Unable to fetch data, error: %d\n",
                             error);
-        goto out;
+        return;
     }
 
     /* M09/M12 does not send header or CRC */
@@ -234,11 +247,11 @@ static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
             dev_err_ratelimited(dev,
                                 "Unexpected header: %02x%02x%02x!\n",
                                 rdbuf[0], rdbuf[1], rdbuf[2]);
-            goto out;
+            return;
         }
 
         if (!edt_ft5x06_ts_check_crc(tsdata, rdbuf, datalen))
-            goto out;
+            return;
     }
 
     for (i = 0; i < tsdata->max_support_points; i++) {
@@ -262,16 +275,20 @@ static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
         id = (buf[2] >> 4) & 0x0f;
 
         input_mt_slot(tsdata->input, id);
-        if (input_mt_report_slot_state(tsdata->input, MT_TOOL_FINGER,
-                                       type != TOUCH_EVENT_UP))
-            touchscreen_report_pos(tsdata->input, &tsdata->prop,
-                                   x, y, true);
+        input_mt_report_slot_state(tsdata->input, MT_TOOL_FINGER, type != TOUCH_EVENT_UP);
+        touchscreen_report_pos(tsdata->input, &tsdata->prop, x, y, true);
     }
 
     input_mt_report_pointer_emulation(tsdata->input, true);
     input_sync(tsdata->input);
+}
 
-    out:
+static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
+{
+    struct edt_ft5x06_ts_data *tsdata = dev_id;
+
+    edt_ft5x06_report(tsdata);
+
     return IRQ_HANDLED;
 }
 
@@ -346,6 +363,26 @@ static int edt_ft5x06_register_read(struct edt_ft5x06_ts_data *tsdata,
     }
 
     return rdbuf[0];
+}
+
+static void edt_ft5x06_poll(struct input_polled_dev *polldev)
+{
+    struct edt_ft5x06_ts_data *tsdata = polldev->private;
+
+    /* Ensure display is always awake */
+    switch (tsdata->version) {
+    case EDT_M06:
+        break;
+    case EDT_M09: /* fall through */
+    case EDT_M12: /* fall through */
+    case EV_FT:
+    case GENERIC_FT:
+        edt_ft5x06_register_write(tsdata, M09_ID_G_PMODE,
+                                  M09_ID_G_PMODE_ACTIVE);
+        break;
+    }
+
+    edt_ft5x06_report(tsdata);
 }
 
 struct edt_ft5x06_attribute {
@@ -815,6 +852,22 @@ static void edt_ft5x06_ts_teardown_debugfs(struct edt_ft5x06_ts_data *tsdata)
 
 #endif /* CONFIG_DEBUGFS */
 
+static int edt_ft5x06_open(struct input_dev *dev)
+{
+    struct edt_ft5x06_ts_data *tsdata = input_get_drvdata(dev);
+
+    enable_irq(tsdata->client->irq);
+
+    return 0;
+}
+
+static void edt_ft5x06_close(struct input_dev *dev)
+{
+    struct edt_ft5x06_ts_data *tsdata = input_get_drvdata(dev);
+
+    disable_irq(tsdata->client->irq);
+}
+
 static int edt_ft5x06_ts_identify(struct i2c_client *client,
                                   struct edt_ft5x06_ts_data *tsdata,
                                   char *fw_version)
@@ -1010,6 +1063,26 @@ edt_ft5x06_ts_get_parameters(struct edt_ft5x06_ts_data *tsdata)
     }
 }
 
+static void edt_ft5x06_ts_set_readout_mode(struct edt_ft5x06_ts_data *tsdata,
+                                           enum readout_mode mode)
+{
+    uint8_t readout_mode;
+
+    switch (tsdata->version) {
+    case EDT_M06:
+        break;
+    case EDT_M09: /* fall through */
+    case EDT_M12: /* fall through */
+    case EV_FT:
+    case GENERIC_FT:
+        readout_mode = (mode == EDT_READOUT_MODE_POLL) ?
+                       M09_ID_G_MODE_POLL :
+                       M09_ID_G_MODE_IRQ;
+        edt_ft5x06_register_write(tsdata, M09_ID_G_MODE, readout_mode);
+        break;
+    }
+}
+
 static void
 edt_ft5x06_ts_set_regs(struct edt_ft5x06_ts_data *tsdata)
 {
@@ -1074,8 +1147,8 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
     const struct edt_i2c_chip_data *chip_data;
     struct edt_ft5x06_ts_data *tsdata;
     u8 buf[2] = { 0xfc, 0x00 };
+
     struct input_dev *input;
-    unsigned long irq_flags;
     int error;
     char fw_version[EDT_NAME_LEN];
 
@@ -1087,7 +1160,7 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
         return -ENOMEM;
     }
 
-    chip_data = device_get_match_data(&client->dev);
+    chip_data = of_device_get_match_data(&client->dev);
     if (!chip_data)
         chip_data = (const struct edt_i2c_chip_data *)id->driver_data;
     if (!chip_data || !chip_data->max_support_points) {
@@ -1137,7 +1210,7 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
     }
 
     /*
-     * Check which sleep modes we can support. Power-off requieres the
+     * Check which sleep modes we can support. Power-off requires the
      * reset-pin to ensure correct power-down/power-up behaviour. Start with
      * the EDT_PMODE_POWEROFF test since this is the deepest possible sleep
      * mode.
@@ -1160,15 +1233,8 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
         msleep(300);
     }
 
-    input = devm_input_allocate_device(&client->dev);
-    if (!input) {
-        dev_err(&client->dev, "failed to allocate input device.\n");
-        return -ENOMEM;
-    }
-
     mutex_init(&tsdata->mutex);
     tsdata->client = client;
-    tsdata->input = input;
     tsdata->factory_mode = false;
 
     error = edt_ft5x06_ts_identify(client, tsdata, fw_version);
@@ -1190,6 +1256,68 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
     dev_dbg(&client->dev,
             "Model \"%s\", Rev. \"%s\", %dx%d sensors\n",
             tsdata->name, fw_version, tsdata->num_x, tsdata->num_y);
+
+// Switch between polled device or IRQ
+
+    if (client->irq) {
+        unsigned long irq_flags;
+
+        irq_flags = irq_get_trigger_type(client->irq);
+        if (irq_flags == IRQF_TRIGGER_NONE)
+            irq_flags = IRQF_TRIGGER_FALLING;
+        irq_flags |= IRQF_ONESHOT;
+
+        error = devm_request_threaded_irq(&client->dev, client->irq,
+                                          NULL, edt_ft5x06_ts_isr, irq_flags,
+                                          client->name, tsdata);
+        if (error) {
+            dev_err(&client->dev, "Unable to request touchscreen IRQ.\n");
+            return error;
+        }
+
+        disable_irq(client->irq);
+
+        input = devm_input_allocate_device(&client->dev);
+        if (!input) {
+            dev_err(&client->dev, "failed to allocate input device.\n");
+            return -ENOMEM;
+        }
+        input->open = edt_ft5x06_open;
+        input->close = edt_ft5x06_close;
+
+        edt_ft5x06_ts_set_readout_mode(tsdata, EDT_READOUT_MODE_IRQ);
+
+        error = input_register_device(input);
+    }
+#if !IS_ENABLED(CONFIG_INPUT_POLLDEV)
+        dev_err(&client->dev, "no IRQ setup and built without INPUT_POLLDEV\n");
+		return -ENODEV;
+#else
+    else {
+        uint32_t poll_interval;
+
+        dev_warn(&client->dev, "no IRQ setup, using polled input\n");
+
+        tsdata->polldev = devm_input_allocate_polled_device(&client->dev);
+        if (!tsdata->polldev) {
+            dev_err(&client->dev, "failed to allocate polldev\n");
+            return -ENOMEM;
+        }
+
+        if (!device_property_read_u32(&client->dev, "poll-interval", &poll_interval))
+            tsdata->polldev->poll_interval = poll_interval;
+
+        tsdata->polldev->private = tsdata;
+        tsdata->polldev->poll = edt_ft5x06_poll;
+        input = tsdata->polldev->input;
+
+        edt_ft5x06_ts_set_readout_mode(tsdata, EDT_READOUT_MODE_POLL);
+
+        error = input_register_polled_device(tsdata->polldev);
+        if (error)
+            dev_err(&client->dev, "Unable to register polled device.\n");
+    }
+#endif
 
     input->name = tsdata->name;
     input->id.bustype = BUS_I2C;
@@ -1221,24 +1349,12 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
 
     i2c_set_clientdata(client, tsdata);
 
-    irq_flags = irq_get_trigger_type(client->irq);
-    if (irq_flags == IRQF_TRIGGER_NONE)
-        irq_flags = IRQF_TRIGGER_FALLING;
-    irq_flags |= IRQF_ONESHOT;
+    tsdata->input = input;
 
-    error = devm_request_threaded_irq(&client->dev, client->irq,
-                                      NULL, edt_ft5x06_ts_isr, irq_flags,
-                                      client->name, tsdata);
-    if (error) {
-        dev_err(&client->dev, "Unable to request touchscreen IRQ.\n");
-        return error;
-    }
-
-    error = devm_device_add_group(&client->dev, &edt_ft5x06_attr_group);
     if (error)
         return error;
 
-    error = input_register_device(input);
+    error = devm_device_add_group(&client->dev, &edt_ft5x06_attr_group);
     if (error)
         return error;
 
@@ -1395,9 +1511,8 @@ MODULE_DEVICE_TABLE(of, edt_ft5x06_of_match);
 static struct i2c_driver edt_ft5x06_ts_driver = {
         .driver = {
                 .name = "edt_ft5x06",
-                .of_match_table = edt_ft5x06_of_match,
+                .of_match_table = of_match_ptr(edt_ft5x06_of_match),
                 .pm = &edt_ft5x06_ts_pm_ops,
-                .probe_type = PROBE_PREFER_ASYNCHRONOUS,
         },
         .id_table = edt_ft5x06_ts_id,
         .probe    = edt_ft5x06_ts_probe,


### PR DESCRIPTION
Normally the driver uses the i2c interrupt line, but we do not have the luxury of this wire in the HDMI cable, therefore we need to poll the IC for touch events. The Linux kernel has a nice subsystem called input-polldev that can handle this. 

The first commit adds the latest driver code taken from mainline 5.9, in order to have the most recent improvements and compatibilities. The second implements the changes to the driver to make polling work. 