### PR TITLE
fbdev: ssd1307fb: Change display refresh frequency from 1 to 15Hz

### DIFF
--- a/drivers/video/fbdev/ssd1307fb.c
+++ b/drivers/video/fbdev/ssd1307fb.c
@@ -44,7 +44,7 @@
 
 #define MAX_CONTRAST 255
 
-#define REFRESHRATE 1
+#define REFRESHRATE 15
 
 static u_int refreshrate = REFRESHRATE;
 module_param(refreshrate, uint, 0);


### PR DESCRIPTION
EM-3628

There are better ways for modifying a module's parameters than changing the source code, but... modifying the refreshrate by means of a parameter to modprobe didn't work.
There are two old commits for this that were removed when the UM3 support was removed, but restoring those old commits didn't fix the slow display.
See:
- jedi-build commit 1832dc6831fd48316caac04dfd6d4ce54e859d5d
- um-kernel commit 5f1b51f7f26a36deafce1f1d3e880bec63bd2765